### PR TITLE
Feature different day horoscope

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -20,7 +20,7 @@ class App extends Component {
         <Header />
         <Switch>
           <Route path='/' exact component={Home} />
-          <Route path='/Horoscope/:sign/Today' exact component={Horoscope} />
+          <Route path='/Horoscope/:sign' exact component={Horoscope} />
           <Route path='/' render={() => <main>404</main>} />
         </Switch>
         <Footer />

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -13,14 +13,14 @@ class App extends Component {
     this.state = {
       isLoading: true,
       errorMsg: '',
-      day: 'today',
+      day: '',
       sign: '',
       horoscope: '',
       image: ''
     }
   }
 
-  retrieveHoroscopeData = async (url, src, alt) => {
+  retrieveHoroscopeData = async (url, src, alt, when) => {
     await fetchHoroscope(url)
     .then(result => {
         this.setState({ isLoading: true, horoscope: '' })
@@ -30,10 +30,11 @@ class App extends Component {
                     isLoading: false,
                     errorMsg: result
                 })
-            }, 1000)
+            }, 600)
           } else {
             setTimeout(() => {
                 this.setState({
+                    day: when || 'today',
                     image: src,
                     sign: alt, 
                     horoscope: result,
@@ -45,16 +46,8 @@ class App extends Component {
   }
 
   retrieveDifferentDay = (when) => {
-    let url;
-    if (when === 'yesterday') {
-        url= `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=yesterday`
-    } else if (when === 'tomorrow') {
-        url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=tomorrow`
-    } else if (when === 'today') {
-        url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
-    }
-    this.retrieveHoroscopeData(url, this.state.image, this.state.sign)
-    this.setState({ day: when })
+    let url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=${when}`;
+    this.retrieveHoroscopeData(url, this.state.image, this.state.sign, when)
   }
 
   goingToPage = (page) => {

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -5,22 +5,64 @@ import Header from '../Header/Header';
 import Home from '../Home/Home';
 import Horoscope from '../Horoscope/Horoscope';
 import Footer from '../Footer/Footer';
+import { fetchHoroscope } from '../../apiCalls';
 
 class App extends Component {
   constructor() {
     super() 
     this.state = {
-
+      sign: '',
+      day: 'today',
+      isLoading: true,
+      errorMsg: '',
+      horoscope: ''
     }
   }
 
+  retrieveHoroscopeData = async (url, alt) => {
+    await fetchHoroscope(url)
+    .then(result => {
+        this.setState({ isLoading: true, horoscope: '' })
+        if (typeof result === 'string') {
+            setTimeout(() => {
+                this.setState({
+                    isLoading: false,
+                    errorMsg: result
+                })
+            }, 1000)
+          } else {
+            setTimeout(() => {
+                this.setState({
+                    sign: alt, 
+                    horoscope: result,
+                    isLoading: false
+                })
+            }, 600)   
+          }
+    })
+  }
+
+  retrieveDifferentDay = (when) => {
+    let url;
+    if (when === 'yesterday') {
+        url= `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=yesterday`
+    } else if (when === 'tomorrow') {
+        url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=tomorrow`
+    } else if (when === 'today') {
+        url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
+    }
+    this.retrieveHoroscopeData(url)
+    this.setState({ day: when })
+  }
+
   render() {
+    console.log(this.state)
     return (
       <div className="App">
         <Header />
         <Switch>
-          <Route path='/' exact component={Home} />
-          <Route path='/Horoscope/:sign' exact component={Horoscope} />
+          <Route path='/' exact render={() => <Home retrieveHoroscopeData={this.retrieveHoroscopeData} />} />
+          <Route path='/Horoscope/:sign' exact render={() => <Horoscope horoscope={this.state}/>} />
           <Route path='/' render={() => <main>404</main>} />
         </Switch>
         <Footer />

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -11,15 +11,16 @@ class App extends Component {
   constructor() {
     super() 
     this.state = {
-      sign: '',
-      day: 'today',
       isLoading: true,
       errorMsg: '',
-      horoscope: ''
+      day: 'today',
+      sign: '',
+      horoscope: '',
+      image: ''
     }
   }
 
-  retrieveHoroscopeData = async (url, alt) => {
+  retrieveHoroscopeData = async (url, src, alt) => {
     await fetchHoroscope(url)
     .then(result => {
         this.setState({ isLoading: true, horoscope: '' })
@@ -33,6 +34,7 @@ class App extends Component {
           } else {
             setTimeout(() => {
                 this.setState({
+                    image: src,
                     sign: alt, 
                     horoscope: result,
                     isLoading: false
@@ -56,7 +58,7 @@ class App extends Component {
   }
 
   render() {
-    console.log(this.state)
+
     return (
       <div className="App">
         <Header />

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -53,7 +53,7 @@ class App extends Component {
     } else if (when === 'today') {
         url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
     }
-    this.retrieveHoroscopeData(url)
+    this.retrieveHoroscopeData(url, this.state.image, this.state.sign)
     this.setState({ day: when })
   }
 
@@ -77,7 +77,7 @@ class App extends Component {
         <Header goingToPage={this.goingToPage}/>
         <Switch>
           <Route path='/' exact render={() => <Home retrieveHoroscopeData={this.retrieveHoroscopeData} />} />
-          <Route path='/Horoscope/:sign' exact render={() => <Horoscope horoscope={this.state}/>} />
+          <Route path='/Horoscope/:sign' exact render={() => <Horoscope horoscope={this.state} retrieveDifferentDay={this.retrieveDifferentDay}/>} />
           <Route path='/' render={() => <main>404</main>} />
         </Switch>
         <Footer />

--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -57,11 +57,24 @@ class App extends Component {
     this.setState({ day: when })
   }
 
+  goingToPage = (page) => {
+    if(page === 'home') {
+      this.setState({
+        isLoading: true,
+        errorMsg: '',
+        day: 'today',
+        sign: '',
+        horoscope: '',
+        image: ''
+      })
+    }
+  }
+
   render() {
 
     return (
       <div className="App">
-        <Header />
+        <Header goingToPage={this.goingToPage}/>
         <Switch>
           <Route path='/' exact render={() => <Home retrieveHoroscopeData={this.retrieveHoroscopeData} />} />
           <Route path='/Horoscope/:sign' exact render={() => <Horoscope horoscope={this.state}/>} />

--- a/src/Components/Header/Header.js
+++ b/src/Components/Header/Header.js
@@ -2,10 +2,11 @@ import React from 'react';
 import { NavLink } from "react-router-dom";
 import './Header.css';
 
-const Header = () => {
+const Header = (props) => {
     return (
         <header>
-            <NavLink to='/'><h1 className="site-title" >Petstrology</h1></NavLink>
+            <NavLink to='/' onClick={() => props.goingToPage('home')}><h1 className="site-title" >Petstrology</h1></NavLink>
+            <NavLink to='/' onClick={() => props.goingToPage('home')}>Home</NavLink>
             <button className="saved-signs-btn">My Saved Signs</button>
         </header>
     )

--- a/src/Components/Home/Home.css
+++ b/src/Components/Home/Home.css
@@ -4,4 +4,10 @@
     flex-wrap: wrap;
     column-gap: 20px;
     row-gap: 20px;
+    animation: fadeIn ease 1.5s;
+}
+
+@keyframes fadeIn {
+    0% {opacity:0;}
+    100% {opacity:1;}
 }

--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -14,7 +14,7 @@ import libra from'../../images/libra.png';
 import scorpio from'../../images/scorpio.png';
 import sagittarius from'../../images/sagittarius.png';
 
-const Home = () => {
+const Home = (props) => {
     const images = [
         {src: capricorn, alt:'capricorn'},
         {src: aquarius, alt: 'aquarius'},
@@ -32,7 +32,7 @@ const Home = () => {
     
     const signComponents = images.map((image, index) => {
         return (
-            <Sign key={index} image={image}/>
+            <Sign key={index} image={image} retrieveHoroscopeData={props.retrieveHoroscopeData}/>
         )
     })
 

--- a/src/Components/Home/Home.js
+++ b/src/Components/Home/Home.js
@@ -16,18 +16,18 @@ import sagittarius from'../../images/sagittarius.png';
 
 const Home = () => {
     const images = [
-        {src: capricorn, alt:'Capricorn'},
-        {src: aquarius, alt: 'Aquarius'},
-        {src: pisces, alt: 'Pisces'},
-        {src: aries, alt: 'Aries'},
-        {src: taurus, alt: 'Taurus'},
-        {src: gemini, alt: 'Gemini'}, 
-        {src: cancer, alt: 'Cancer'}, 
-        {src: leo, alt: 'Leo'},
-        {src: virgo, alt: 'Virgo'},
-        {src: libra, alt: 'Libra'},
-        {src: scorpio, alt: 'Scorpio'}, 
-        {src: sagittarius, alt: 'Sagittarius'}
+        {src: capricorn, alt:'capricorn'},
+        {src: aquarius, alt: 'aquarius'},
+        {src: pisces, alt: 'pisces'},
+        {src: aries, alt: 'aries'},
+        {src: taurus, alt: 'taurus'},
+        {src: gemini, alt: 'gemini'}, 
+        {src: cancer, alt: 'cancer'}, 
+        {src: leo, alt: 'leo'},
+        {src: virgo, alt: 'virgo'},
+        {src: libra, alt: 'libra'},
+        {src: scorpio, alt: 'scorpio'}, 
+        {src: sagittarius, alt: 'sagittarius'}
     ];
     
     const signComponents = images.map((image, index) => {

--- a/src/Components/Horoscope/Horoscope.css
+++ b/src/Components/Horoscope/Horoscope.css
@@ -1,6 +1,7 @@
 .horoscope-content {
     display: flex;
     flex-direction: row;
+    animation: fadeIn ease 1.5s;
 }
 
 .horoscope-sign-img,
@@ -25,4 +26,9 @@
 .today,
 .tomorrow {
     width: 50%;
+}
+
+@keyframes fadeIn {
+    0% {opacity:0;}
+    100% {opacity:1;}
 }

--- a/src/Components/Horoscope/Horoscope.css
+++ b/src/Components/Horoscope/Horoscope.css
@@ -1,4 +1,4 @@
-.horoscope-main {
+.horoscope-content {
     display: flex;
     flex-direction: row;
 }

--- a/src/Components/Horoscope/Horoscope.css
+++ b/src/Components/Horoscope/Horoscope.css
@@ -28,6 +28,12 @@
     width: 50%;
 }
 
+.error-message,
+.loading-message {
+    text-align: center;
+    padding: 50px;
+}
+
 @keyframes fadeIn {
     0% {opacity:0;}
     100% {opacity:1;}

--- a/src/Components/Horoscope/Horoscope.css
+++ b/src/Components/Horoscope/Horoscope.css
@@ -20,3 +20,9 @@
 .horoscope-sign-title {
     color: rgb(148,84,110);
 }
+
+.yesterday,
+.today,
+.tomorrow {
+    width: 50%;
+}

--- a/src/Components/Horoscope/Horoscope.css
+++ b/src/Components/Horoscope/Horoscope.css
@@ -10,7 +10,8 @@
 }
 
 .details {
-    padding: 20px;
+    padding: 5px 10px 5px 20px;
+    text-align: center;
 }
 
 .horoscope-sign-img {
@@ -20,6 +21,7 @@
 
 .horoscope-sign-title {
     color: rgb(148,84,110);
+    margin: 0 0 5px 0;
 }
 
 .yesterday,
@@ -34,6 +36,18 @@
     padding: 50px;
 }
 
+h3 {
+    margin: 0;
+}
+
+ul {
+    padding: 0;
+}
+
+li {
+    list-style-type: none;
+    margin-bottom: 5px;
+}
 @keyframes fadeIn {
     0% {opacity:0;}
     100% {opacity:1;}

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -14,14 +14,15 @@ const Horoscope = (props) => {
                     <div className='details'>
                         <h2 className='horoscope-sign-title'>{sign.toUpperCase()}</h2>
                             <ul>
-                                <li className='days-date'>Current Date: {horoscope.current_date}</li>
-                                <li className='date-range'>Birthday Range: {horoscope.date_range}</li>
-                                <li className='days-color'>Color: {horoscope.color}</li>
-                                <li className='days-compatibility'>Compatibility: {horoscope.compatibility}</li>
-                                <li className='days-description'>Description: {horoscope.description}</li>
-                                <li className='days-lucky-numbers'>Lucky Number: {horoscope.lucky_number}</li>
-                                <li className='days-lucky-time'>Lucky Time: {horoscope.lucky_time}</li>
-                                <li className='days-mood'>Mood: {horoscope.mood}</li>
+                                <li className='days-date'><h3>Current Date:</h3> {horoscope.current_date}</li>
+                                <li className='date-range'><h3>Birthday Range:</h3> {horoscope.date_range}</li>
+                                <li className='days-color'><h3>Color:</h3> {horoscope.color}</li>
+                                <li className='days-compatibility'><h3>Compatibility:</h3> {horoscope.compatibility}</li>
+                               
+                                <li className='days-lucky-numbers'><h3>Lucky Number:</h3> {horoscope.lucky_number}</li>
+                                <li className='days-lucky-time'><h3>Lucky Time:</h3> {horoscope.lucky_time}</li>
+                                <li className='days-mood'><h3>Mood:</h3> {horoscope.mood}</li>
+                                 <li className='days-description'><h3>Description:</h3> {horoscope.description}</li>
                             </ul>
                             {day !== 'yesterday' && <button className='yesterday' onClick={() => props.retrieveDifferentDay('yesterday')}>Yesterday</button>}
                             {day !== 'today' && <button className='today' onClick={() => props.retrieveDifferentDay('today')}>Today</button>}

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import './Horoscope.css';
-// import { fetchHoroscope } from '../../apiCalls';
 
 const Horoscope = (props) => {
     const { day, isLoading, errorMsg, horoscope, image, alt, signTitle } = props.horoscope;

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -1,65 +1,64 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './Horoscope.css';
-import { fetchHoroscope } from '../../apiCalls';
+// import { fetchHoroscope } from '../../apiCalls';
 
-class Horoscope extends Component {
-    constructor(props) {
-        super(props)
-        this.state = {
-            sign: this.props.location.state.alt,
-            day: 'today',
-            isLoading: true,
-            errorMsg: '',
-            horoscope: ''
-        }
-    }
+const Horoscope = (props) => {
 
-    componentDidMount() {
-        this.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`)
-    }
+        // this.state = {
+        //     sign: this.props.location.state.alt,
+        //     day: 'today',
+        //     isLoading: true,
+        //     errorMsg: '',
+        //     horoscope: ''
+        // }
+    // }
 
-    retrieveHoroscopeData = async (url) => {
-        await fetchHoroscope(url)
-        .then(result => {
-            this.setState({ isLoading: true, horoscope: '' })
-            if (typeof result === 'string') {
-                setTimeout(() => {
-                    this.setState({
-                        isLoading: false,
-                        errorMsg: result
-                    })
-                }, 1000)
-              } else {
-                setTimeout(() => {
-                    this.setState({
-                        horoscope: result,
-                        isLoading: false
-                    })
-                }, 1000)   
-              }
-        })
-    }
+    // componentDidMount() {
+    //     this.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`)
+    // }
 
-    retrieveDifferentDay = (when) => {
-        let url;
-        if (when === 'yesterday') {
-            url= `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=yesterday`
-        } else if (when === 'tomorrow') {
-            url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=tomorrow`
-        } else if (when === 'today') {
-            url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
-        }
-        this.retrieveHoroscopeData(url)
-        this.setState({ day: when })
-    }
+    // retrieveHoroscopeData = async (url) => {
+    //     await fetchHoroscope(url)
+    //     .then(result => {
+    //         this.setState({ isLoading: true, horoscope: '' })
+    //         if (typeof result === 'string') {
+    //             setTimeout(() => {
+    //                 this.setState({
+    //                     isLoading: false,
+    //                     errorMsg: result
+    //                 })
+    //             }, 1000)
+    //           } else {
+    //             setTimeout(() => {
+    //                 this.setState({
+    //                     horoscope: result,
+    //                     isLoading: false
+    //                 })
+    //             }, 600)   
+    //           }
+    //     })
+    // }
 
-    render() {
-        const { src, alt, signTitle } = this.props.location.state;
-        const { day, isLoading, errorMsg, horoscope } = this.state;
+    // retrieveDifferentDay = (when) => {
+    //     let url;
+    //     if (when === 'yesterday') {
+    //         url= `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=yesterday`
+    //     } else if (when === 'tomorrow') {
+    //         url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=tomorrow`
+    //     } else if (when === 'today') {
+    //         url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
+    //     }
+    //     this.retrieveHoroscopeData(url)
+    //     this.setState({ day: when })
+    // }
 
+
+        // const { src, alt, signTitle } = this.props.location.state;
+        // const { day, isLoading, errorMsg, horoscope, src, alt, signTitle } = this.props;
+        // console.log(props)
         return (
-            <main className="horoscope-main">
-                <img className='horoscope-sign-img' src={src} alt={alt} />
+            <main className="horoscope-main">merp
+                {/* <img className='horoscope-sign-img' src={src} alt={alt} />
                 <div className='details'>
                     <h2 className='horoscope-sign-title'>{signTitle}</h2>
                     {errorMsg && <p className='error-message'>{errorMsg}</p>}
@@ -81,10 +80,10 @@ class Horoscope extends Component {
                         {day !== 'tomorrow' && <button className='tomorrow' onClick={() => this.retrieveDifferentDay('tomorrow')}>Tomorrow</button>}
                     </section>
                     }     
-                </div>
+                </div> */}
             </main>
         )
     }
-}
+
 
 export default Horoscope; 

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -6,6 +6,7 @@ class Horoscope extends Component {
     constructor(props) {
         super(props)
         this.state = {
+            sign: this.props.location.state.alt,
             isLoading: true,
             errorMsg: '',
             horoscope: ''
@@ -13,7 +14,7 @@ class Horoscope extends Component {
     }
 
     componentDidMount() {
-        fetchHoroscope('https://aztro.sameerkumar.website/?sign=aries&day=today')
+        fetchHoroscope(`https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`)
         .then(result => {
             if (typeof result === 'string') {
                 this.setState({
@@ -32,7 +33,7 @@ class Horoscope extends Component {
     render() {
         const { src, alt, signTitle } = this.props.location.state;
         const { isLoading, errorMsg, horoscope } = this.state;
-        console.log(horoscope)
+
         return (
             <main className="horoscope-main">
                 <img className='horoscope-sign-img' src={src} alt={alt} />

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -21,16 +21,21 @@ class Horoscope extends Component {
     retrieveHoroscopeData = async (url) => {
         await fetchHoroscope(url)
         .then(result => {
+            this.setState({ isLoading: true, horoscope: '' })
             if (typeof result === 'string') {
-                this.setState({
-                  isLoading: false,
-                  errorMsg: result
-                })
+                setTimeout(() => {
+                    this.setState({
+                        isLoading: false,
+                        errorMsg: result
+                    })
+                }, 1000)
               } else {
-                this.setState({
-                    horoscope: result,
-                    isLoading: false
-                  })
+                setTimeout(() => {
+                    this.setState({
+                        horoscope: result,
+                        isLoading: false
+                    })
+                }, 1000)   
               }
         })
     }

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -3,87 +3,36 @@ import './Horoscope.css';
 // import { fetchHoroscope } from '../../apiCalls';
 
 const Horoscope = (props) => {
+    const { day, isLoading, errorMsg, horoscope, image, alt, signTitle } = props.horoscope;
 
-        // this.state = {
-        //     sign: this.props.location.state.alt,
-        //     day: 'today',
-        //     isLoading: true,
-        //     errorMsg: '',
-        //     horoscope: ''
-        // }
-    // }
-
-    // componentDidMount() {
-    //     this.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`)
-    // }
-
-    // retrieveHoroscopeData = async (url) => {
-    //     await fetchHoroscope(url)
-    //     .then(result => {
-    //         this.setState({ isLoading: true, horoscope: '' })
-    //         if (typeof result === 'string') {
-    //             setTimeout(() => {
-    //                 this.setState({
-    //                     isLoading: false,
-    //                     errorMsg: result
-    //                 })
-    //             }, 1000)
-    //           } else {
-    //             setTimeout(() => {
-    //                 this.setState({
-    //                     horoscope: result,
-    //                     isLoading: false
-    //                 })
-    //             }, 600)   
-    //           }
-    //     })
-    // }
-
-    // retrieveDifferentDay = (when) => {
-    //     let url;
-    //     if (when === 'yesterday') {
-    //         url= `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=yesterday`
-    //     } else if (when === 'tomorrow') {
-    //         url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=tomorrow`
-    //     } else if (when === 'today') {
-    //         url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
-    //     }
-    //     this.retrieveHoroscopeData(url)
-    //     this.setState({ day: when })
-    // }
-
-
-        // const { src, alt, signTitle } = this.props.location.state;
-        // const { day, isLoading, errorMsg, horoscope, src, alt, signTitle } = this.props;
-        // console.log(props)
-        return (
-            <main className="horoscope-main">merp
-                {/* <img className='horoscope-sign-img' src={src} alt={alt} />
-                <div className='details'>
-                    <h2 className='horoscope-sign-title'>{signTitle}</h2>
-                    {errorMsg && <p className='error-message'>{errorMsg}</p>}
-                    {isLoading && <p className='loading-message'>Loading...</p>}
-                    {horoscope  && 
-                    <section>
-                        <ul>
-                            <li className='days-date'>Current Date: {horoscope.current_date}</li>
-                            <li className='date-range'>Birthday Range: {horoscope.date_range}</li>
-                            <li className='days-color'>Color: {horoscope.color}</li>
-                            <li className='days-compatibility'>Compatibility: {horoscope.compatibility}</li>
-                            <li className='days-description'>Description: {horoscope.description}</li>
-                            <li className='days-lucky-numbers'>Lucky Number: {horoscope.lucky_number}</li>
-                            <li className='days-lucky-time'>Lucky Time: {horoscope.lucky_time}</li>
-                            <li className='days-mood'>Mood: {horoscope.mood}</li>
-                        </ul>
-                        {day !== 'yesterday' && <button className='yesterday' onClick={() => this.retrieveDifferentDay('yesterday')}>Yesterday</button>}
-                        {day !== 'today' && <button className='today' onClick={() => this.retrieveDifferentDay('today')}>Today</button>}
-                        {day !== 'tomorrow' && <button className='tomorrow' onClick={() => this.retrieveDifferentDay('tomorrow')}>Tomorrow</button>}
-                    </section>
-                    }     
-                </div> */}
-            </main>
-        )
-    }
+    return (
+        <main className="horoscope-main">
+            {errorMsg && <p className='error-message'>{errorMsg}</p>}
+            {isLoading && <p className='loading-message'>Loading...</p>}
+            {horoscope  &&   
+                <section className="horoscope-content">
+                    <img className='horoscope-sign-img' src={image} alt={alt} />
+                    <div className='details'>
+                        <h2 className='horoscope-sign-title'>{signTitle}</h2>
+                            <ul>
+                                <li className='days-date'>Current Date: {horoscope.current_date}</li>
+                                <li className='date-range'>Birthday Range: {horoscope.date_range}</li>
+                                <li className='days-color'>Color: {horoscope.color}</li>
+                                <li className='days-compatibility'>Compatibility: {horoscope.compatibility}</li>
+                                <li className='days-description'>Description: {horoscope.description}</li>
+                                <li className='days-lucky-numbers'>Lucky Number: {horoscope.lucky_number}</li>
+                                <li className='days-lucky-time'>Lucky Time: {horoscope.lucky_time}</li>
+                                <li className='days-mood'>Mood: {horoscope.mood}</li>
+                            </ul>
+                            {day !== 'yesterday' && <button className='yesterday' onClick={() => this.retrieveDifferentDay('yesterday')}>Yesterday</button>}
+                            {day !== 'today' && <button className='today' onClick={() => this.retrieveDifferentDay('today')}>Today</button>}
+                            {day !== 'tomorrow' && <button className='tomorrow' onClick={() => this.retrieveDifferentDay('tomorrow')}>Tomorrow</button>} 
+                    </div>
+                </section>
+            }   
+        </main>
+    )
+}
 
 
 export default Horoscope; 

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -7,6 +7,7 @@ class Horoscope extends Component {
         super(props)
         this.state = {
             sign: this.props.location.state.alt,
+            day: 'today',
             isLoading: true,
             errorMsg: '',
             horoscope: ''
@@ -14,7 +15,11 @@ class Horoscope extends Component {
     }
 
     componentDidMount() {
-        fetchHoroscope(`https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`)
+        this.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`)
+    }
+
+    retrieveHoroscopeData = async (url) => {
+        await fetchHoroscope(url)
         .then(result => {
             if (typeof result === 'string') {
                 this.setState({
@@ -30,9 +35,23 @@ class Horoscope extends Component {
         })
     }
 
+    retrieveDifferentDay = (when) => {
+        let url;
+        if (when === 'yesterday') {
+            url= `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=yesterday`
+        } else if (when === 'tomorrow') {
+            url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=tomorrow`
+        } else if (when === 'today') {
+            url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
+        }
+        console.log(url)
+        this.retrieveHoroscopeData(url)
+        this.setState({ day: when })
+    }
+
     render() {
         const { src, alt, signTitle } = this.props.location.state;
-        const { isLoading, errorMsg, horoscope } = this.state;
+        const { day, isLoading, errorMsg, horoscope } = this.state;
 
         return (
             <main className="horoscope-main">
@@ -53,9 +72,9 @@ class Horoscope extends Component {
                             <li className='days-lucky-time'>Lucky Time: {horoscope.lucky_time}</li>
                             <li className='days-mood'>Mood: {horoscope.mood}</li>
                         </ul>
-                        <button className='yesterday'>Yesterday</button>
-                        <button className='today'>Today</button>
-                        <button className='tomorrow'>Tomorrow</button>
+                        {day !== 'yesterday' && <button className='yesterday' onClick={() => this.retrieveDifferentDay('yesterday')}>Yesterday</button>}
+                        {day !== 'today' && <button className='today'>Today</button>}
+                        {day !== 'tomorrow' && <button className='tomorrow'>Tomorrow</button>}
                     </section>
                     }     
                 </div>

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -2,7 +2,7 @@ import React from 'react';
 import './Horoscope.css';
 
 const Horoscope = (props) => {
-    const { day, isLoading, errorMsg, horoscope, image, alt, signTitle } = props.horoscope;
+    const { day, isLoading, errorMsg, horoscope, image, alt, sign } = props.horoscope;
 
     return (
         <main className="horoscope-main">
@@ -12,7 +12,7 @@ const Horoscope = (props) => {
                 <section className="horoscope-content">
                     <img className='horoscope-sign-img' src={image} alt={alt} />
                     <div className='details'>
-                        <h2 className='horoscope-sign-title'>{signTitle}</h2>
+                        <h2 className='horoscope-sign-title'>{sign.toUpperCase()}</h2>
                             <ul>
                                 <li className='days-date'>Current Date: {horoscope.current_date}</li>
                                 <li className='date-range'>Birthday Range: {horoscope.date_range}</li>
@@ -23,9 +23,9 @@ const Horoscope = (props) => {
                                 <li className='days-lucky-time'>Lucky Time: {horoscope.lucky_time}</li>
                                 <li className='days-mood'>Mood: {horoscope.mood}</li>
                             </ul>
-                            {day !== 'yesterday' && <button className='yesterday' onClick={() => this.retrieveDifferentDay('yesterday')}>Yesterday</button>}
-                            {day !== 'today' && <button className='today' onClick={() => this.retrieveDifferentDay('today')}>Today</button>}
-                            {day !== 'tomorrow' && <button className='tomorrow' onClick={() => this.retrieveDifferentDay('tomorrow')}>Tomorrow</button>} 
+                            {day !== 'yesterday' && <button className='yesterday' onClick={() => props.retrieveDifferentDay('yesterday')}>Yesterday</button>}
+                            {day !== 'today' && <button className='today' onClick={() => props.retrieveDifferentDay('today')}>Today</button>}
+                            {day !== 'tomorrow' && <button className='tomorrow' onClick={() => props.retrieveDifferentDay('tomorrow')}>Tomorrow</button>} 
                     </div>
                 </section>
             }   

--- a/src/Components/Horoscope/Horoscope.js
+++ b/src/Components/Horoscope/Horoscope.js
@@ -44,7 +44,6 @@ class Horoscope extends Component {
         } else if (when === 'today') {
             url = `https://aztro.sameerkumar.website/?sign=${this.state.sign}&day=today`
         }
-        console.log(url)
         this.retrieveHoroscopeData(url)
         this.setState({ day: when })
     }
@@ -73,8 +72,8 @@ class Horoscope extends Component {
                             <li className='days-mood'>Mood: {horoscope.mood}</li>
                         </ul>
                         {day !== 'yesterday' && <button className='yesterday' onClick={() => this.retrieveDifferentDay('yesterday')}>Yesterday</button>}
-                        {day !== 'today' && <button className='today'>Today</button>}
-                        {day !== 'tomorrow' && <button className='tomorrow'>Tomorrow</button>}
+                        {day !== 'today' && <button className='today' onClick={() => this.retrieveDifferentDay('today')}>Today</button>}
+                        {day !== 'tomorrow' && <button className='tomorrow' onClick={() => this.retrieveDifferentDay('tomorrow')}>Tomorrow</button>}
                     </section>
                     }     
                 </div>

--- a/src/Components/Sign/Sign.js
+++ b/src/Components/Sign/Sign.js
@@ -13,7 +13,7 @@ const Sign = (props) => {
                 pathname: `/Horoscope/${alt}`
             }} 
             className='sign-link'
-            onClick={() => props.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${alt}&day=today`, alt)}
+            onClick={() => props.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${alt}&day=today`, src, alt)}
         >
             <article className='all-star-signs'>
                 <h2 className='sign-title'>{signTitle}</h2>

--- a/src/Components/Sign/Sign.js
+++ b/src/Components/Sign/Sign.js
@@ -4,15 +4,16 @@ import './Sign.css';
 
 const Sign = (props) => {
     const { src, alt } = props.image;
+    // const { retrieveHoroscopeDate } = props.retrieveHoroscopeDate;
     const signTitle = alt.toUpperCase();
-
+// console.log(props)
     return (
         <Link 
             to={{
-                pathname: `/Horoscope/${alt}`,
-                state: {src, alt, signTitle}
+                pathname: `/Horoscope/${alt}`
             }} 
             className='sign-link'
+            onClick={() => props.retrieveHoroscopeData(`https://aztro.sameerkumar.website/?sign=${alt}&day=today`, alt)}
         >
             <article className='all-star-signs'>
                 <h2 className='sign-title'>{signTitle}</h2>

--- a/src/Components/Sign/Sign.js
+++ b/src/Components/Sign/Sign.js
@@ -9,7 +9,7 @@ const Sign = (props) => {
     return (
         <Link 
             to={{
-                pathname: `/Horoscope/${alt}/Today`,
+                pathname: `/Horoscope/${alt}`,
                 state: {src, alt, signTitle}
             }} 
             className='sign-link'


### PR DESCRIPTION
What does this PR do?
Display horoscope information on horoscope page
Include functionality for today, tomorrow, and yesterday buttons
Store state on app and pass information through props
DDAA

What does it feature/fix?
Feature the horoscope information that is fetched from the api depending on the sign selected and the date chosen, default is today.

Where should the reviewer start?
App.js line 14

How should this be tested?
Should be able to select a sign, see the correct sign's today horoscope, then can use the buttons to toggle between today, tomorrow, and yesterday.

What are the next steps or any issues/concerns?
Create functionality to look up what sign you are, save your favorite signs
Testing
